### PR TITLE
Set textwidth=88 for Python files in (n)vim

### DIFF
--- a/vim/.vim/ftplugin/python.vim
+++ b/vim/.vim/ftplugin/python.vim
@@ -1,3 +1,6 @@
+" Chosen to be consistent with psf/black coding style.
+set textwidth=88
+
 if executable('python3')
   let g:python = 'python3'
 else


### PR DESCRIPTION
Consistent with the black coding style: https://github.com/psf/black

Closes #40.